### PR TITLE
**feature: Add a codecov file to avoid red cross**

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+comment: false


### PR DESCRIPTION
_Commit Description:_

Add a codecov file to avoir red cross that says the project did not pass, and avoid the 'double comment'.