### PR TITLE
**feature: Make CodeCov ignore extern folder, and main.cpp files**

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,3 +7,7 @@ coverage:
       default:
         informational: true
 comment: false
+ignore:
+  - "extern"
+  - "reports"
+  - "**/main.cpp"


### PR DESCRIPTION
_Commit Description:_

Make CodeCov ignore extern folder, and main.cpp files for code coverage badge.